### PR TITLE
Add unique IDs to Slide-Atlas menu buttons

### DIFF
--- a/glviewer/static/annotationWidget.js
+++ b/glviewer/static/annotationWidget.js
@@ -17,7 +17,7 @@ function AnnotationWidget (viewer) {
     viewer.AnnotationWidget = this;
     
     if ( ! MOBILE_DEVICE) {
-        this.Tab = new Tab("/webgl-viewer/static/pencil3Up.png");
+        this.Tab = new Tab("/webgl-viewer/static/pencil3Up.png", "annotationTab");
         viewer.AddGuiObject(this.Tab.Div, "Bottom", 0, "Right", 140);
         new ToolTip(this.Tab.Div, "Annotation");
 

--- a/glviewer/static/conferenceWidget.js
+++ b/glviewer/static/conferenceWidget.js
@@ -25,7 +25,7 @@ function ConferenceWidget () {
     var self = this; // trick to set methods in callbacks.
     
     if ( ! MOBILE_DEVICE) {
-        this.Tab = new Tab("/webgl-viewer/static/conference1.png");
+        this.Tab = new Tab("/webgl-viewer/static/conference1.png", "conferenceTab");
         new ToolTip(this.Tab.Div, "Conference");
         this.Tab.Div
             .css({'left': '250px',

--- a/glviewer/static/navigationWidget.js
+++ b/glviewer/static/navigationWidget.js
@@ -47,7 +47,7 @@ function NavigationWidget() {
                             'bottom' : bottom,
                             'z-index': '5'});
     } else {
-        this.Tab = new Tab("/webgl-viewer/static/nav.png");
+        this.Tab = new Tab("/webgl-viewer/static/nav.png", "navigationTab");
         new ToolTip(this.Tab.Div, "Navigation");
         this.Tab.Div.css({'left': '50px',
                           'bottom': '0px'});

--- a/glviewer/static/tab.js
+++ b/glviewer/static/tab.js
@@ -7,12 +7,12 @@ Tab = (function () {
 
     // If a tabbed object is specified, only one tab for the object
     // will be allowed open at a time.
-    function Tab (imageSrc) {
+    function Tab (imageSrc, tabID) {
         var self = this; // trick to set methods in callbacks.
 
         this.Div = $('<div>')
             .appendTo(VIEW_PANEL)
-            .attr('id', 'debug')
+            .attr('id', tabID)
             .css({'z-index' : '5',
                   'position': 'absolute'});
 

--- a/glviewer/static/viewEditMenu.js
+++ b/glviewer/static/viewEditMenu.js
@@ -14,7 +14,7 @@
 function ViewEditMenu (viewer) {
     var self = this; // trick to set methods in callbacks.
     this.Viewer = viewer;
-    this.Tab = new Tab("/webgl-viewer/static/Menu.jpg");
+    this.Tab = new Tab("/webgl-viewer/static/Menu.jpg", "editTab");
     // I think we can get rid of this "GuiObject" stuff.
     // css positioning can handle it now.
     viewer.AddGuiObject(this.Tab.Div, "Bottom", 0, "Right", 99);

--- a/glviewer/static/viewer.js
+++ b/glviewer/static/viewer.js
@@ -289,7 +289,7 @@ Viewer.prototype.RollMove = function (e) {
 
 Viewer.prototype.InitializeZoomGui = function() {
     // Put the zoom bottons in a tab.
-    this.ZoomTab = new Tab("/webgl-viewer/static/mag.png");
+    this.ZoomTab = new Tab("/webgl-viewer/static/mag.png", "zoomTab");
     new ToolTip(this.ZoomTab.Div, "Zoom scroll");
     // TODO: Get rid of this Gui object stuff and just rely on css positioning.
     this.AddGuiObject(this.ZoomTab.Div, "Bottom", 0, "Right", 37);

--- a/testing/frontend/selenium/test_glViewer_menus.py
+++ b/testing/frontend/selenium/test_glViewer_menus.py
@@ -1,0 +1,57 @@
+from selenium import webdriver
+import unittest
+import re
+import argparse
+
+driver = webdriver.Firefox()
+
+class glViewerTests(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    global driver
+
+
+  @classmethod
+  def tearDownClass(cls):
+    global driver
+    driver.close()
+
+  def test_tabs(self):
+    global driver
+    # Ensure only proper amount of elements exist
+    # navigation tab = 1
+    # annotation tab = 2
+    # edit tab = 2
+    # zoom tab = 2
+    # conference tab = 0?
+
+    # Open second widget so every button is accessible
+    driver.find_element_by_id("dualWidgetLeft").click()
+
+    # Set tab IDs and expected number of found elements with ID
+    tab_values = {"zoomTab": 2, "navigationTab": 1, "annotationTab": 2, "editTab": 2, "conferenceTab": 0}
+    for tab_id in tab_values.keys():
+      button_list = driver.find_elements_by_id(tab_id)
+
+      # Assert that expected found equals actually found value
+      self.assertTrue(len(button_list) == tab_values[tab_id])
+
+      #Click on each button (specifically, each img within each named ID element)
+      # Ensure that other sub-div now has a 'display: block' string within its style
+      # Menu is then visible
+      for button in button_list:
+        button.find_element_by_tag_name('img').click()
+        style_text = button.find_element_by_tag_name('div').get_attribute("style")
+        self.assertTrue(re.match("display: block", style_text))
+
+if __name__ == "__main__":
+  # Read in passed argument which is webroot of Slide-Atlas Instance to test
+  parser = argparse.ArgumentParser(description="First test suite of Slide-Atlas web front end")
+  parser.add_argument("-r",dest = 'webroot' , required=True, help ="Web root of the Slide-Atlas instance to test: eg 'http://localhost:8080/'")
+  result = vars(parser.parse_args())
+  # Use global driver to access viewer page of Slide-Atlas
+  driver.get(result['webroot'] + "webgl-viewer?edit=true&db=53f27d6b0ac87a9930fb31fb&view=53f7b89838a5881254eb5d83")
+  # Run test(s)
+  suite = unittest.TestLoader().loadTestsFromTestCase(glViewerTests)
+  unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Add the capability to specify the ID of each type of  button which is
found in the Slide-Atlas UI.

Add a test to test for the correct number of available buttons and ensures
that each button generates a visible menu.

The test uses Selenium and Python.  it only requires one argument which is
passed with the '-r' flag.  That argument is the webroot of the
Slide-Atlas instance with the trailing slash.
For example
  python test_glViewer_menus.py -r "http://localhost:8080/"

The test will open the "HD001 Renal Infarct - Coagulative Necrosis" view