### PR TITLE
Add to Slide-Atlas Selenium tests

### DIFF
--- a/testing/frontend/selenium/test_glViewer_menus.py
+++ b/testing/frontend/selenium/test_glViewer_menus.py
@@ -1,23 +1,41 @@
+#---------------------------------------------------------------------------
+# Copyright 2015 Kitware Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#---------------------------------------------------------------------------
 from selenium import webdriver
 import unittest
 import re
+import time
 import argparse
 
-driver = webdriver.Firefox()
+
 
 class glViewerTests(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
     global driver
-
+    tab_widget = driver.find_element_by_id("dualWidgetLeft")
+    if tab_widget.is_displayed():
+      tab_widget.click()
 
   @classmethod
   def tearDownClass(cls):
     global driver
     driver.close()
 
-  def test_tabs(self):
+  def test_01_tabs(self):
     global driver
     # Ensure only proper amount of elements exist
     # navigation tab = 1
@@ -25,9 +43,6 @@ class glViewerTests(unittest.TestCase):
     # edit tab = 2
     # zoom tab = 2
     # conference tab = 0?
-
-    # Open second widget so every button is accessible
-    driver.find_element_by_id("dualWidgetLeft").click()
 
     # Set tab IDs and expected number of found elements with ID
     tab_values = {"zoomTab": 2, "navigationTab": 1, "annotationTab": 2, "editTab": 2, "conferenceTab": 0}
@@ -45,13 +60,72 @@ class glViewerTests(unittest.TestCase):
         style_text = button.find_element_by_tag_name('div').get_attribute("style")
         self.assertTrue(re.match("display: block", style_text))
 
+  def test_09_annotationTab(self):
+    global driver
+    annot_tab = driver.find_element_by_id('annotationTab')
+    annot_tab.click()
+    annot_menu = annot_tab.find_element_by_xpath('//*[@id="annotationTab"]/div')
+    for button in annot_menu.find_elements_by_tag_name("img"):
+      old_style = button.get_attribute("style")
+      button.click()
+      time.sleep(2)
+      self.assertTrue(button.get_attribute("style") != old_style)
+
+  def _3_editTab(self):
+    global driver
+    annot_tab = driver.find_element_by_id('editTab')
+    annot_menu = annot_tab.find_element_by_xpath('//*[@id="editTab"]/div')
+    for button in annot_menu.find_elements_by_tag_name("button"):
+      annot_tab.click()
+      old_style = button.get_attribute("style")
+      button.click()
+      time.sleep(2)
+      self.assertTrue(button.get_attribute("style") != old_style)
+
+  def test_04_navTab(self):
+    global driver
+    nav_tab = driver.find_element_by_id('navigationTab')
+    nav_tab.click()
+    nav_menu = nav_tab.find_element_by_tag_name('div')
+    old_table_num = len(driver.find_elements_by_tag_name('table'))
+    for button in nav_menu.find_elements_by_tag_name("img"):
+      button.click()
+    new_table_num = len(driver.find_elements_by_tag_name('table'))
+    self.assertTrue(old_table_num != new_table_num)
+
+
+  def test_02_zoomTab(self):
+    global driver
+    zoom_tabs = driver.find_elements_by_id("zoomTab")
+    oldText = zoom_tabs[1].text
+    zoom_tabs[1].find_element_by_tag_name("img").click()
+    annot_menu = zoom_tabs[1].find_element_by_tag_name('div')
+    for button in annot_menu.find_elements_by_tag_name("img"):
+      button.click()
+    time.sleep(2)
+    zoom_tabs = driver.find_elements_by_id("zoomTab")
+    self.assertTrue(zoom_tabs[1].text != oldText)
+
+  def test_03_editTab(self):
+    global driver
+    editTabs = driver.find_elements_by_id("editTab")
+    editTabs[1].find_element_by_tag_name("img").click()
+    time.sleep(10)
+    edit_menu = editTabs[1].find_element_by_tag_name("div")
+    #for button in edit_menu.find_elements_by_tag_name('button'):
+    #  if not button.is_displayed():
+    #    editTabs[1].find_element_by_tag_name("img").click()
+    # button.click()
+
+
 if __name__ == "__main__":
   # Read in passed argument which is webroot of Slide-Atlas Instance to test
   parser = argparse.ArgumentParser(description="First test suite of Slide-Atlas web front end")
   parser.add_argument("-r",dest = 'webroot' , required=True, help ="Web root of the Slide-Atlas instance to test: eg 'http://localhost:8080/'")
   result = vars(parser.parse_args())
   # Use global driver to access viewer page of Slide-Atlas
-  driver.get(result['webroot'] + "webgl-viewer?edit=true&db=53f27d6b0ac87a9930fb31fb&view=53f7b89838a5881254eb5d83")
+  driver = webdriver.Firefox()
+  driver.get(result['webroot'] + "webgl-viewer?db=5074589002e31023d4292d83&view=544f92d6dd98b515418f3302")
   # Run test(s)
   suite = unittest.TestLoader().loadTestsFromTestCase(glViewerTests)
   unittest.TextTestRunner(verbosity=2).run(suite)

--- a/testing/frontend/selenium/test_glViewer_previewNav.py
+++ b/testing/frontend/selenium/test_glViewer_previewNav.py
@@ -1,0 +1,72 @@
+#---------------------------------------------------------------------------
+# Copyright 2015 Kitware Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#---------------------------------------------------------------------------
+from selenium import webdriver
+from selenium.webdriver.common.action_chains import ActionChains
+import unittest
+import time
+import re
+import argparse
+
+
+class glViewer_nav_Tests(unittest.TestCase):
+
+  @classmethod
+  def setUpClass(cls):
+    global driver
+    # Open second widget so every button is accessible
+    tab_widget = driver.find_element_by_id("dualWidgetLeft")
+    if tab_widget.is_displayed():
+      tab_widget.click()
+
+
+  @classmethod
+  def tearDownClass(cls):
+    global driver
+    driver.close()
+
+  def test_01_rotation(self):
+    global driver
+    nav_widget = driver.find_element_by_xpath('//*[@id="body"]/div[4]/div[5]')
+    rot_pic = nav_widget.find_element_by_tag_name("img")
+    old_style = nav_widget.get_attribute("style")
+    ActionChains(driver).move_to_element(rot_pic).click_and_hold(rot_pic).move_by_offset(-50, 0).release().perform()
+    time.sleep(2)
+    self.assertTrue(nav_widget.get_attribute("style") != old_style)
+
+  # Figure the resizing issue, cannot click and drag to resize the
+  # Navigation widget/canvas
+  def _test_02_resize(self):
+    global driver
+    nav_widget = driver.find_element_by_xpath('//*[@id="body"]/div[4]/div[5]')
+    nav_canvas = nav_widget.find_element_by_tag_name("canvas")
+    old_width = nav_canvas.get_attribute("width")
+    old_height = nav_canvas.get_attribute("height")
+    ActionChains(driver).move_to_element(nav_widget).drag_and_drop_by_offset(nav_canvas,-500,0).perform()
+    self.assertTrue(nav_canvas.get_attribute("width") > old_width)
+    self.assertTrue(nav_canvas.get_attribute("height") > old_height)
+
+if __name__ == "__main__":
+  # Read in passed argument which is webroot of Slide-Atlas Instance to test
+  parser = argparse.ArgumentParser(description="First test suite of Slide-Atlas web front end")
+  parser.add_argument("-r",dest = 'webroot' , required=True, help ="Web root of the Slide-Atlas instance to test: eg 'http://localhost:8080/'")
+  result = vars(parser.parse_args())
+  # Use global driver to access viewer page of Slide-Atlas
+
+  driver = webdriver.Firefox()
+  driver.get(result['webroot'] + "webgl-viewer?db=5074589002e31023d4292d83&view=544f92d6dd98b515418f3302")
+  # Run test(s)
+  suite = unittest.TestLoader().loadTestsFromTestCase(glViewer_nav_Tests)
+  unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
Change the page to be loaded for each test to be one of the images
available for all users, signed in or not.

Add file with interaction for the navigation canvas testing the rotation
of the widget and add the skeleton of a test for changing the size of the
canvas.

Add interactions with each menu button's content to attempt to exercise
each option within the popup menu.  Comment out the editTab content as it
seems to hide other elements.